### PR TITLE
Feature notification logic

### DIFF
--- a/src/client/userclient/client.go
+++ b/src/client/userclient/client.go
@@ -1,15 +1,19 @@
 package userclient
 
 import (
+	"bookem-notification-service/util"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 type UserClient interface {
-	FindById(it uint) (*UserDTO, error)
+	FindById(context context.Context, it uint) (*UserDTO, error)
 }
 
 type userClient struct {
@@ -22,30 +26,37 @@ func NewUserClient() UserClient {
 	}
 }
 
-func (c *userClient) FindById(id uint) (*UserDTO, error) {
-	log.Printf("Find user %d", id)
+func (c *userClient) FindById(context context.Context, id uint) (*UserDTO, error) {
+	util.TEL.Info("find user", "user_id", id)
 
-	resp, err := http.Get(fmt.Sprintf("%s/%d", c.baseURL, id))
-
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%d", c.baseURL, id), nil)
 	if err != nil {
-		log.Printf("Error %v", err)
+		util.TEL.Error("could not create request", err)
+		return nil, err
+	}
+	otel.GetTextMapPropagator().Inject(context, propagation.HeaderCarrier(req.Header))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		util.TEL.Error("could not send request", err)
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("User %d not found: http %d", id, resp.StatusCode)
+		util.TEL.Error("user not found", nil, "user_id", id, "http", resp.StatusCode)
 		return nil, fmt.Errorf("user %d not found", id)
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("Parsing response error: %v", err)
+		util.TEL.Error("could not parse bytes from response", err)
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var obj UserDTO
 	if err := json.Unmarshal(bodyBytes, &obj); err != nil {
-		log.Printf("JSON Unmarshall error: %v", err)
+		util.TEL.Error("could not unmarshall JSON", err)
 		return nil, err
 	}
 

--- a/src/client/userclient/model.go
+++ b/src/client/userclient/model.go
@@ -1,13 +1,5 @@
 package userclient
 
-type UserRole string
-
-const (
-	Guest UserRole = "guest"
-	Host  UserRole = "host"
-	Admin UserRole = "admin"
-)
-
 type UserCreateDTO struct {
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/src/go.sum
+++ b/src/go.sum
@@ -135,6 +135,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -2,7 +2,7 @@ package internal
 
 import "time"
 
-type NewNotificationDTO struct {
+type CreateNotificationDTO struct {
 	ReceiverID  uint             `json:"receiverId"`
 	Type        NotificationType `json:"type"`
 	Subject     uint             `json:"subject"`
@@ -19,6 +19,19 @@ type NotificationDTO struct {
 	StarsNumber int              `json:"starsNumber,omitempty"`
 	IsRead      bool             `json:"isRead"`
 	CreatedAt   time.Time        `json:"createdAt"`
+}
+
+func NewNotificationDTO(n *Notification) NotificationDTO {
+	return NotificationDTO{
+		ID:          n.ID.Hex(),
+		ReceiverID:  n.ReceiverID,
+		Type:        n.Type,
+		Subject:     n.Subject,
+		Object:      n.Object,
+		StarsNumber: n.StarsNumber,
+		IsRead:      n.IsRead,
+		CreatedAt:   n.CreatedAt,
+	}
 }
 
 type NotificationPreferencesDTO struct {

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -3,25 +3,25 @@ package internal
 import "time"
 
 type NewNotificationDTO struct {
-	ReceiverID  string           `json:"receiverId"`
+	ReceiverID  uint             `json:"receiverId"`
 	Type        NotificationType `json:"type"`
-	Subject     string           `json:"subject"`
-	Object      string           `json:"object"`
+	Subject     uint             `json:"subject"`
+	Object      uint             `json:"object"`
 	StarsNumber int              `json:"starsNumber,omitempty"`
 }
 
 type NotificationDTO struct {
 	ID          string           `json:"id"`
-	ReceiverID  string           `json:"receiverId"`
+	ReceiverID  uint             `json:"receiverId"`
 	Type        NotificationType `json:"type"`
-	Subject     string           `json:"subject"`
-	Object      string           `json:"object"`
+	Subject     uint             `json:"subject"`
+	Object      uint             `json:"object"`
 	StarsNumber int              `json:"starsNumber,omitempty"`
 	IsRead      bool             `json:"isRead"`
 	CreatedAt   time.Time        `json:"createdAt"`
 }
 
 type NotificationPreferencesDTO struct {
-	UserID       string                    `json:"userId"`
+	UserID       uint                      `json:"userId"`
 	EnabledTypes map[NotificationType]bool `json:"enabledTypes"`
 }

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -1,5 +1,27 @@
 package internal
 
+import "time"
+
+type NewNotificationDTO struct {
+	ReceiverID  string           `json:"receiverId"`
+	Type        NotificationType `json:"type"`
+	Subject     string           `json:"subject"`
+	Object      string           `json:"object"`
+	StarsNumber int              `json:"starsNumber,omitempty"`
+}
+
 type NotificationDTO struct {
-	ID uint `json:"id"`
+	ID          string           `json:"id"`
+	ReceiverID  string           `json:"receiverId"`
+	Type        NotificationType `json:"type"`
+	Subject     string           `json:"subject"`
+	Object      string           `json:"object"`
+	StarsNumber int              `json:"starsNumber,omitempty"`
+	IsRead      bool             `json:"isRead"`
+	CreatedAt   time.Time        `json:"createdAt"`
+}
+
+type NotificationPreferencesDTO struct {
+	UserID       string                    `json:"userId"`
+	EnabledTypes map[NotificationType]bool `json:"enabledTypes"`
 }

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bookem-notification-service/client/userclient"
 	"bookem-notification-service/util"
 	"net/http"
 
@@ -13,7 +12,7 @@ type Route struct{ handler Handler }
 func NewRoute(handler Handler) *Route { return &Route{handler} }
 
 func (r *Route) Route(rg *gin.RouterGroup) {
-	rg.POST("/new", r.handler.createNotification)
+	rg.POST("/notification", r.handler.createNotification)
 }
 
 type Handler struct{ service Service }
@@ -21,25 +20,32 @@ type Handler struct{ service Service }
 func NewHandler(s Service) Handler { return Handler{s} }
 
 func (h *Handler) createNotification(ctx *gin.Context) {
+	util.TEL.Push(ctx.Request.Context(), "create-notification-api")
+	defer util.TEL.Pop()
+
 	jwt, err := util.GetJwt(ctx)
 	if err != nil {
+		util.TEL.Error("failed fetching JWT", err)
 		AbortError(ctx, ErrUnauthenticated)
 		return
 	}
 
-	if jwt.Role != userclient.Guest && jwt.Role != userclient.Host {
+	if jwt.Role != util.Guest && jwt.Role != util.Host {
+		util.TEL.Error("user is not guest or host", nil, "role", jwt.Role)
 		AbortError(ctx, ErrUnauthorized)
 		return
 	}
 
-	var dto NotificationDTO
+	var dto NewNotificationDTO
 	if err := ctx.ShouldBindJSON(&dto); err != nil {
-		AbortError(ctx, err)
+		util.TEL.Error("failed binding JSON", err)
+		AbortError(ctx, ErrBadRequestCustom("invalid request body"))
 		return
 	}
 
-	notification, err := h.service.Create(ctx, jwt.ID, dto)
+	notification, err := h.service.CreateNotification(util.TEL.Ctx(), jwt.ID, dto)
 	if err != nil {
+		util.TEL.Error("failed creating notification", err)
 		AbortError(ctx, err)
 		return
 	}

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -14,7 +14,9 @@ func NewRoute(handler Handler) *Route { return &Route{handler} }
 
 func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/notification", r.handler.createNotification)
-	rg.GET("/notifications:limit", r.handler.getUserNotifications)
+	rg.GET("/notifications/:limit", r.handler.getUserNotifications)
+	rg.PUT("/notifications/:id/read", r.handler.markNotificationAsRead)
+
 }
 
 type Handler struct{ service Service }
@@ -82,4 +84,29 @@ func (h *Handler) getUserNotifications(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, notifications)
+}
+
+func (h *Handler) markNotificationAsRead(ctx *gin.Context) {
+	util.TEL.Push(ctx.Request.Context(), "mark-notification-as-read-api")
+	defer util.TEL.Pop()
+
+	jwt, err := util.GetJwt(ctx)
+	if err != nil {
+		util.TEL.Error("failed fetching JWT", err)
+		AbortError(ctx, ErrUnauthenticated)
+		return
+	}
+
+	notificationID := ctx.Param("id")
+	if notificationID == "" {
+		AbortError(ctx, ErrBadRequestCustom("notification ID is required"))
+		return
+	}
+
+	if err := h.service.MarkNotificationAsRead(util.TEL.Ctx(), jwt.ID, notificationID); err != nil {
+		AbortError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "notification marked as read"})
 }

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -41,7 +41,7 @@ func (h *Handler) createNotification(ctx *gin.Context) {
 		return
 	}
 
-	var dto NewNotificationDTO
+	var dto CreateNotificationDTO
 	if err := ctx.ShouldBindJSON(&dto); err != nil {
 		util.TEL.Error("failed binding JSON", err)
 		AbortError(ctx, ErrBadRequestCustom("invalid request body"))
@@ -55,7 +55,7 @@ func (h *Handler) createNotification(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusCreated, notification)
+	ctx.JSON(http.StatusCreated, NewNotificationDTO(notification))
 }
 
 func (h *Handler) getUserNotifications(ctx *gin.Context) {
@@ -93,7 +93,14 @@ func (h *Handler) getUserNotifications(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, notifications)
+	util.TEL.Debug("building response")
+
+	result := make([]NotificationDTO, 0)
+	for _, notif := range notifications {
+		result = append(result, NewNotificationDTO(&notif))
+	}
+
+	ctx.JSON(http.StatusOK, result)
 }
 
 func (h *Handler) markNotificationAsRead(ctx *gin.Context) {

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bookem-notification-service/util"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -13,6 +14,7 @@ func NewRoute(handler Handler) *Route { return &Route{handler} }
 
 func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/notification", r.handler.createNotification)
+	rg.GET("/notifications:limit", r.handler.getUserNotifications)
 }
 
 type Handler struct{ service Service }
@@ -51,4 +53,33 @@ func (h *Handler) createNotification(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusCreated, notification)
+}
+
+func (h *Handler) getUserNotifications(ctx *gin.Context) {
+	util.TEL.Push(ctx.Request.Context(), "get-notifications-api")
+	defer util.TEL.Pop()
+
+	jwt, err := util.GetJwt(ctx)
+	if err != nil {
+		util.TEL.Error("failed fetching JWT", err)
+		AbortError(ctx, ErrUnauthenticated)
+		return
+	}
+
+	limitStr := ctx.DefaultQuery("limit", "10")
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		util.TEL.Error("could not parse limit query param into a number", err, "limit", limitStr)
+		AbortError(ctx, err)
+		return
+	}
+
+	notifications, err := h.service.GetUserNotifications(util.TEL.Ctx(), jwt.ID, limit)
+	if err != nil {
+		util.TEL.Error("failed fetching notifications", err)
+		AbortError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, notifications)
 }

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -14,7 +14,7 @@ func NewRoute(handler Handler) *Route { return &Route{handler} }
 
 func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/notification", r.handler.createNotification)
-	rg.GET("/notifications/:limit", r.handler.getUserNotifications)
+	rg.GET("/notifications", r.handler.getUserNotifications)
 	rg.PUT("/notifications/:id/read", r.handler.markNotificationAsRead)
 
 }
@@ -69,14 +69,23 @@ func (h *Handler) getUserNotifications(ctx *gin.Context) {
 	}
 
 	limitStr := ctx.DefaultQuery("limit", "10")
+	offsetStr := ctx.DefaultQuery("offset", "0")
+
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil || limit <= 0 {
-		util.TEL.Error("could not parse limit query param into a number", err, "limit", limitStr)
-		AbortError(ctx, err)
+		util.TEL.Error("invalid limit query param", err, "limit", limitStr)
+		AbortError(ctx, ErrBadRequestCustom("invalid limit"))
 		return
 	}
 
-	notifications, err := h.service.GetUserNotifications(util.TEL.Ctx(), jwt.ID, limit)
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		util.TEL.Error("invalid offset query param", err, "offset", offsetStr)
+		AbortError(ctx, ErrBadRequestCustom("invalid offset"))
+		return
+	}
+
+	notifications, err := h.service.GetUserNotifications(util.TEL.Ctx(), jwt.ID, limit, offset)
 	if err != nil {
 		util.TEL.Error("failed fetching notifications", err)
 		AbortError(ctx, err)

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -16,6 +16,7 @@ func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/notification", r.handler.createNotification)
 	rg.GET("/notifications", r.handler.getUserNotifications)
 	rg.PUT("/notifications/:id/read", r.handler.markNotificationAsRead)
+	rg.GET("/notifications/unread-count", r.handler.getUnreadNotificationCount)
 
 }
 
@@ -118,4 +119,25 @@ func (h *Handler) markNotificationAsRead(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, gin.H{"message": "notification marked as read"})
+}
+
+func (h *Handler) getUnreadNotificationCount(ctx *gin.Context) {
+	util.TEL.Push(ctx.Request.Context(), "get-unread-notifications-count")
+	defer util.TEL.Pop()
+
+	jwt, err := util.GetJwt(ctx)
+	if err != nil {
+		util.TEL.Error("failed fetching JWT", err)
+		AbortError(ctx, ErrUnauthenticated)
+		return
+	}
+
+	count, err := h.service.GetUnreadNotificationCount(util.TEL.Ctx(), jwt.ID)
+	if err != nil {
+		util.TEL.Error("failed fetching unread notification count", err)
+		AbortError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"unreadCount": count})
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -1,9 +1,35 @@
 package internal
 
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type NotificationType string
+
+const (
+	ReservationRequested NotificationType = "reservation_requested"
+	ReservationCancelled NotificationType = "reservation_cancelled"
+	HostReviewed         NotificationType = "host_reviewed"
+	RoomReviewed         NotificationType = "room_reviewed"
+	ReservationAccepted  NotificationType = "reservation_accepted"
+	ReservationDeclined  NotificationType = "reservation_declined"
+)
+
 type Notification struct {
-	ID uint
+	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	ReceiverID  string             `bson:"receiverId" json:"receiverId"`
+	Type        NotificationType   `bson:"type" json:"type"`
+	Subject     string             `bson:"subject" json:"subject"`
+	Object      string             `bson:"object,omitempty" json:"object"`
+	StarsNumber int                `bson:"starsNumber,omitempty" json:"starsNumber,omitempty"`
+	IsRead      bool               `bson:"isRead" json:"isRead"`
+	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
 }
 
-type Preference struct {
-	ID uint
+type NotificationPreferences struct {
+	ID           primitive.ObjectID        `bson:"_id,omitempty" json:"id"`
+	UserID       string                    `bson:"userId" json:"userId"`
+	EnabledTypes map[NotificationType]bool `bson:"types" json:"types"`
 }

--- a/src/internal/model.go
+++ b/src/internal/model.go
@@ -19,10 +19,10 @@ const (
 
 type Notification struct {
 	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	ReceiverID  string             `bson:"receiverId" json:"receiverId"`
+	ReceiverID  uint               `bson:"receiverId" json:"receiverId"`
 	Type        NotificationType   `bson:"type" json:"type"`
-	Subject     string             `bson:"subject" json:"subject"`
-	Object      string             `bson:"object,omitempty" json:"object"`
+	Subject     uint               `bson:"subject" json:"subject"`
+	Object      uint               `bson:"object,omitempty" json:"object"`
 	StarsNumber int                `bson:"starsNumber,omitempty" json:"starsNumber,omitempty"`
 	IsRead      bool               `bson:"isRead" json:"isRead"`
 	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
@@ -30,6 +30,6 @@ type Notification struct {
 
 type NotificationPreferences struct {
 	ID           primitive.ObjectID        `bson:"_id,omitempty" json:"id"`
-	UserID       string                    `bson:"userId" json:"userId"`
+	UserID       uint                      `bson:"userId" json:"userId"`
 	EnabledTypes map[NotificationType]bool `bson:"types" json:"types"`
 }

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -15,6 +15,7 @@ type Repository interface {
 	FindByReceiverID(ctx context.Context, receiverID uint, limit int, offset int) ([]Notification, error)
 	MarkAsRead(ctx context.Context, id string) error
 	FindByID(ctx context.Context, id string) (*Notification, error)
+	CountUnreadNotifications(ctx context.Context, receiverID uint) (int64, error)
 }
 
 type repository struct {
@@ -92,4 +93,20 @@ func (r *repository) FindByID(ctx context.Context, id string) (*Notification, er
 	}
 
 	return &notification, nil
+}
+
+func (r *repository) CountUnreadNotifications(ctx context.Context, receiverID uint) (int64, error) {
+	coll := r.db.Collection("notifications")
+
+	filter := bson.M{
+		"receiverId": receiverID,
+		"isRead":     false,
+	}
+
+	count, err := coll.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -3,11 +3,15 @@ package internal
 import (
 	"context"
 
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Repository interface {
-	Create(ctx context.Context, notification *Notification) error
+	Save(ctx context.Context, notification *Notification) (*Notification, error)
+	FindByReceiverID(ctx context.Context, receiverID string) ([]Notification, error)
+	MarkAsRead(ctx context.Context, id string) error
 }
 
 type repository struct {
@@ -18,8 +22,47 @@ func NewRepository(db *mongo.Database) Repository {
 	return &repository{db}
 }
 
-func (r *repository) Create(ctx context.Context, notification *Notification) error {
-	//todo implement this method
-	_, err := r.db.Collection("notifications").InsertOne(ctx, notification)
+func (r *repository) Save(ctx context.Context, n *Notification) (*Notification, error) {
+	coll := r.db.Collection("notifications")
+
+	res, err := coll.InsertOne(ctx, n)
+	if err != nil {
+		return nil, err
+	}
+
+	n.ID = res.InsertedID.(primitive.ObjectID)
+	return n, nil
+}
+
+func (r *repository) FindByReceiverID(ctx context.Context, receiverID string) ([]Notification, error) {
+	coll := r.db.Collection("notifications")
+
+	cursor, err := coll.Find(ctx, bson.M{"receiverId": receiverID})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var notifications []Notification
+	if err := cursor.All(ctx, &notifications); err != nil {
+		return nil, err
+	}
+
+	return notifications, nil
+}
+
+func (r *repository) MarkAsRead(ctx context.Context, id string) error {
+	coll := r.db.Collection("notifications")
+
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+
+	_, err = coll.UpdateOne(
+		ctx,
+		bson.M{"_id": objID},
+		bson.M{"$set": bson.M{"isRead": true}},
+	)
 	return err
 }

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -12,7 +12,7 @@ import (
 
 type Repository interface {
 	Save(ctx context.Context, notification *Notification) (*Notification, error)
-	FindByReceiverID(ctx context.Context, receiverID uint, limit int) ([]Notification, error)
+	FindByReceiverID(ctx context.Context, receiverID uint, limit int, offset int) ([]Notification, error)
 	MarkAsRead(ctx context.Context, id string) error
 	FindByID(ctx context.Context, id string) (*Notification, error)
 }
@@ -37,12 +37,13 @@ func (r *repository) Save(ctx context.Context, n *Notification) (*Notification, 
 	return n, nil
 }
 
-func (r *repository) FindByReceiverID(ctx context.Context, receiverID uint, limit int) ([]Notification, error) {
+func (r *repository) FindByReceiverID(ctx context.Context, receiverID uint, limit int, offset int) ([]Notification, error) {
 	coll := r.db.Collection("notifications")
 
 	opts := options.Find().
 		SetSort(bson.D{{Key: "createdAt", Value: -1}}).
-		SetLimit(int64(limit))
+		SetLimit(int64(limit)).
+		SetSkip(int64(offset))
 
 	cursor, err := coll.Find(ctx, bson.M{"receiverId": receiverID}, opts)
 	if err != nil {

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -6,11 +6,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type Repository interface {
 	Save(ctx context.Context, notification *Notification) (*Notification, error)
-	FindByReceiverID(ctx context.Context, receiverID string) ([]Notification, error)
+	FindByReceiverID(ctx context.Context, receiverID uint, limit int) ([]Notification, error)
 	MarkAsRead(ctx context.Context, id string) error
 }
 
@@ -34,10 +35,14 @@ func (r *repository) Save(ctx context.Context, n *Notification) (*Notification, 
 	return n, nil
 }
 
-func (r *repository) FindByReceiverID(ctx context.Context, receiverID string) ([]Notification, error) {
+func (r *repository) FindByReceiverID(ctx context.Context, receiverID uint, limit int) ([]Notification, error) {
 	coll := r.db.Collection("notifications")
 
-	cursor, err := coll.Find(ctx, bson.M{"receiverId": receiverID})
+	opts := options.Find().
+		SetSort(bson.D{{Key: "createdAt", Value: -1}}).
+		SetLimit(int64(limit))
+
+	cursor, err := coll.Find(ctx, bson.M{"receiverId": receiverID}, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -13,6 +14,7 @@ type Repository interface {
 	Save(ctx context.Context, notification *Notification) (*Notification, error)
 	FindByReceiverID(ctx context.Context, receiverID uint, limit int) ([]Notification, error)
 	MarkAsRead(ctx context.Context, id string) error
+	FindByID(ctx context.Context, id string) (*Notification, error)
 }
 
 type repository struct {
@@ -70,4 +72,23 @@ func (r *repository) MarkAsRead(ctx context.Context, id string) error {
 		bson.M{"$set": bson.M{"isRead": true}},
 	)
 	return err
+}
+
+func (r *repository) FindByID(ctx context.Context, id string) (*Notification, error) {
+	coll := r.db.Collection("notifications")
+
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return nil, err
+	}
+
+	var notification Notification
+	if err := coll.FindOne(ctx, bson.M{"_id": objID}).Decode(&notification); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("notification not found: %w", err)
+		}
+		return nil, err
+	}
+
+	return &notification, nil
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -10,7 +10,7 @@ import (
 
 type Service interface {
 	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
-	GetUserNotifications(ctx context.Context, userID uint, limit int) ([]Notification, error)
+	GetUserNotifications(ctx context.Context, userID uint, limit int, offset int) ([]Notification, error)
 	MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error
 }
 
@@ -83,8 +83,8 @@ func (s *service) CreateNotification(ctx context.Context, callerID uint, dto New
 	return saved, nil
 }
 
-func (s *service) GetUserNotifications(ctx context.Context, userID uint, limit int) ([]Notification, error) {
-	util.TEL.Info("fetching notifications for user", nil, "user_id", userID, "limit", limit)
+func (s *service) GetUserNotifications(ctx context.Context, userID uint, limit int, offset int) ([]Notification, error) {
+	util.TEL.Info("fetching notifications for user", nil, "user_id", userID, "limit", limit, "offset", offset)
 
 	util.TEL.Debug("check if user exists", nil, "id", userID)
 	_, err := s.userClient.FindById(util.TEL.Ctx(), userID)
@@ -95,7 +95,7 @@ func (s *service) GetUserNotifications(ctx context.Context, userID uint, limit i
 
 	util.TEL.Push(ctx, "find-user-notifications-in-db")
 	defer util.TEL.Pop()
-	return s.repo.FindByReceiverID(ctx, userID, limit)
+	return s.repo.FindByReceiverID(ctx, userID, limit, offset)
 }
 
 func (s *service) MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error {

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -2,12 +2,14 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	"bookem-notification-service/client/userclient"
+	"bookem-notification-service/util"
 )
 
 type Service interface {
-	Create(ctx context.Context, callerID uint, dto NotificationDTO) (*Notification, error)
+	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
 }
 
 type service struct {
@@ -21,7 +23,60 @@ func NewService(
 	return &service{repo, userClient}
 }
 
-func (s *service) Create(ctx context.Context, callerID uint, dto NotificationDTO) (*Notification, error) {
-	notification := &Notification{}
-	return notification, s.repo.Create(ctx, notification)
+// CreateNotification - stores a new notification in MongoDB
+func (s *service) CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error) {
+	util.TEL.Info("user initiates creating a notification", nil, "caller_id", callerID)
+
+	util.TEL.Debug("check if user exists", nil, "id", callerID)
+	user, err := s.userClient.FindById(util.TEL.Ctx(), callerID)
+	if err != nil {
+		util.TEL.Error("user does not exist", err, "id", callerID)
+		return nil, ErrUnauthenticated
+	}
+
+	util.TEL.Debug("check if user is a guest or host", nil, "id", callerID)
+	if user.Role != string(util.Guest) {
+		if user.Role != string(util.Host) {
+			util.TEL.Error("user has a bad role", nil, "role", user.Role)
+			return nil, ErrUnauthorized
+		}
+	}
+
+	util.TEL.Info("creating new notification", nil, "receiver_id", dto.ReceiverID, "type", dto.Type)
+
+	if dto.ReceiverID == 0 {
+		util.TEL.Error("missing receiver ID", nil)
+		return nil, ErrBadRequestCustom("receiver ID cannot be empty")
+	}
+
+	util.TEL.Debug("check if receiver exists", nil, "id", dto.ReceiverID)
+	receiver, err := s.userClient.FindById(util.TEL.Ctx(), dto.ReceiverID)
+	if err != nil {
+		util.TEL.Error("receiver does not exist", err, "id", dto.ReceiverID)
+		return nil, ErrBadRequestCustom("receiver does not exist")
+	}
+
+	if dto.Type == "" {
+		util.TEL.Error("missing notification type", nil)
+		return nil, ErrBadRequestCustom("notification type cannot be empty")
+	}
+
+	notification := &Notification{
+		ReceiverID:  receiver.Id,
+		Type:        dto.Type,
+		Subject:     dto.Subject,
+		Object:      dto.Object,
+		StarsNumber: dto.StarsNumber,
+		IsRead:      false,
+		CreatedAt:   time.Now(),
+	}
+
+	saved, err := s.repo.Save(ctx, notification)
+	if err != nil {
+		util.TEL.Error("failed to save notification", err)
+		return nil, err
+	}
+
+	util.TEL.Info("notification successfully created", "notification_id", saved.ID)
+	return saved, nil
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Service interface {
-	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
+	CreateNotification(ctx context.Context, callerID uint, dto CreateNotificationDTO) (*Notification, error)
 	GetUserNotifications(ctx context.Context, userID uint, limit int, offset int) ([]Notification, error)
 	MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error
 	GetUnreadNotificationCount(ctx context.Context, userID uint) (int64, error)
@@ -27,7 +27,7 @@ func NewService(
 }
 
 // CreateNotification - stores a new notification in MongoDB
-func (s *service) CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error) {
+func (s *service) CreateNotification(ctx context.Context, callerID uint, dto CreateNotificationDTO) (*Notification, error) {
 	util.TEL.Info("user initiates creating a notification", nil, "caller_id", callerID)
 
 	util.TEL.Debug("check if user exists", nil, "id", callerID)

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -12,6 +12,7 @@ type Service interface {
 	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
 	GetUserNotifications(ctx context.Context, userID uint, limit int, offset int) ([]Notification, error)
 	MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error
+	GetUnreadNotificationCount(ctx context.Context, userID uint) (int64, error)
 }
 
 type service struct {
@@ -128,4 +129,25 @@ func (s *service) MarkNotificationAsRead(ctx context.Context, callerID uint, not
 
 	util.TEL.Info("notification marked as read", "notification_id", notificationID)
 	return nil
+}
+
+func (s *service) GetUnreadNotificationCount(ctx context.Context, userID uint) (int64, error) {
+	util.TEL.Info("fetching unread notifications for user", nil, "user_id", userID)
+
+	util.TEL.Debug("check if user exists", nil, "id", userID)
+	_, err := s.userClient.FindById(util.TEL.Ctx(), userID)
+	if err != nil {
+		util.TEL.Error("user does not exist", err, "id", userID)
+		return 0, ErrUnauthenticated
+	}
+
+	util.TEL.Push(ctx, "find-user-notifications-in-db")
+	defer util.TEL.Pop()
+
+	count, err := s.repo.CountUnreadNotifications(ctx, userID)
+	if err != nil {
+		util.TEL.Error("failed counting unread notifications", err, "user_id", userID)
+		return 0, err
+	}
+	return count, nil
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -22,8 +22,6 @@ func NewService(
 }
 
 func (s *service) Create(ctx context.Context, callerID uint, dto NotificationDTO) (*Notification, error) {
-	notification := &Notification{
-		ID: dto.ID,
-	}
+	notification := &Notification{}
 	return notification, s.repo.Create(ctx, notification)
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -11,6 +11,7 @@ import (
 type Service interface {
 	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
 	GetUserNotifications(ctx context.Context, userID uint, limit int) ([]Notification, error)
+	MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error
 }
 
 type service struct {
@@ -95,4 +96,36 @@ func (s *service) GetUserNotifications(ctx context.Context, userID uint, limit i
 	util.TEL.Push(ctx, "find-user-notifications-in-db")
 	defer util.TEL.Pop()
 	return s.repo.FindByReceiverID(ctx, userID, limit)
+}
+
+func (s *service) MarkNotificationAsRead(ctx context.Context, callerID uint, notificationID string) error {
+	util.TEL.Info("mark notification as read", "caller_id", callerID, "notification_id", notificationID)
+
+	util.TEL.Debug("check if user exists", nil, "id", callerID)
+	_, err := s.userClient.FindById(util.TEL.Ctx(), callerID)
+	if err != nil {
+		util.TEL.Error("user does not exist", err, "id", callerID)
+		return ErrUnauthenticated
+	}
+
+	util.TEL.Debug("check if notification exists", nil, "id", notificationID)
+	notification, err := s.repo.FindByID(ctx, notificationID)
+	if err != nil {
+		util.TEL.Error("notification not found", err, "notification_id", notificationID)
+		return ErrBadRequestCustom("notification does not exist")
+	}
+
+	util.TEL.Debug("check if user owns this notification", nil, "id", notificationID)
+	if notification.ReceiverID != callerID {
+		util.TEL.Error("user tried to mark notification not belonging to them", nil, "caller_id", callerID, "receiver_id", notification.ReceiverID)
+		return ErrUnauthorized
+	}
+
+	if err := s.repo.MarkAsRead(ctx, notificationID); err != nil {
+		util.TEL.Error("failed marking notification as read", err, "notification_id", notificationID)
+		return err
+	}
+
+	util.TEL.Info("notification marked as read", "notification_id", notificationID)
+	return nil
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -10,6 +10,7 @@ import (
 
 type Service interface {
 	CreateNotification(ctx context.Context, callerID uint, dto NewNotificationDTO) (*Notification, error)
+	GetUserNotifications(ctx context.Context, userID uint, limit int) ([]Notification, error)
 }
 
 type service struct {
@@ -79,4 +80,19 @@ func (s *service) CreateNotification(ctx context.Context, callerID uint, dto New
 
 	util.TEL.Info("notification successfully created", "notification_id", saved.ID)
 	return saved, nil
+}
+
+func (s *service) GetUserNotifications(ctx context.Context, userID uint, limit int) ([]Notification, error) {
+	util.TEL.Info("fetching notifications for user", nil, "user_id", userID, "limit", limit)
+
+	util.TEL.Debug("check if user exists", nil, "id", userID)
+	_, err := s.userClient.FindById(util.TEL.Ctx(), userID)
+	if err != nil {
+		util.TEL.Error("user does not exist", err, "id", userID)
+		return nil, ErrUnauthenticated
+	}
+
+	util.TEL.Push(ctx, "find-user-notifications-in-db")
+	defer util.TEL.Pop()
+	return s.repo.FindByReceiverID(ctx, userID, limit)
 }

--- a/src/test/integration/create_notification_test.go
+++ b/src/test/integration/create_notification_test.go
@@ -14,7 +14,7 @@ func TestCreateNotificationIntegration(t *testing.T) {
 	guestUser := SetupGuestUser(t)
 
 	// Host creates a notification for guest
-	dto := internal.NewNotificationDTO{
+	dto := internal.CreateNotificationDTO{
 		ReceiverID: uint(guestUser.ID),
 		Type:       "reservation_requested",
 		Subject:    0,

--- a/src/test/integration/create_notification_test.go
+++ b/src/test/integration/create_notification_test.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateNotificationIntegration(t *testing.T) {
+	hostUser := SetupHostUser(t)
+	guestUser := SetupGuestUser(t)
+
+	// Host creates a notification for guest
+	dto := internal.NewNotificationDTO{
+		ReceiverID: uint(guestUser.ID),
+		Type:       "reservation_requested",
+		Subject:    0,
+		Object:     0,
+	}
+
+	resp, err := CreateNotification(hostUser.JWT, dto)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	notif := ResponseToNotification(resp)
+	assert.Equal(t, dto.Type, notif.Type)
+	assert.Equal(t, dto.ReceiverID, notif.ReceiverID)
+	assert.False(t, notif.IsRead)
+}

--- a/src/test/integration/get_unread_notification_count_test.go
+++ b/src/test/integration/get_unread_notification_count_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUnreadNotificationCountIntegration(t *testing.T) {
+	guestUser := SetupGuestUser(t)
+	hostUser := SetupHostUser(t)
+
+	// Create 3 notifications
+	for i := 0; i < 3; i++ {
+		dto := internal.NewNotificationDTO{
+			ReceiverID: uint(guestUser.ID),
+			Type:       "reservation_requested",
+			Subject:    0,
+			Object:     0,
+		}
+		resp, _ := CreateNotification(hostUser.JWT, dto)
+		defer resp.Body.Close()
+	}
+
+	// Get unread count
+	resp, err := GetUnreadNotificationCount(guestUser.JWT)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	count := ResponseToUnreadCount(resp)
+	assert.GreaterOrEqual(t, count, int64(3))
+}

--- a/src/test/integration/get_unread_notification_count_test.go
+++ b/src/test/integration/get_unread_notification_count_test.go
@@ -15,7 +15,7 @@ func TestGetUnreadNotificationCountIntegration(t *testing.T) {
 
 	// Create 3 notifications
 	for i := 0; i < 3; i++ {
-		dto := internal.NewNotificationDTO{
+		dto := internal.CreateNotificationDTO{
 			ReceiverID: uint(guestUser.ID),
 			Type:       "reservation_requested",
 			Subject:    0,

--- a/src/test/integration/get_user_notifications_test.go
+++ b/src/test/integration/get_user_notifications_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserNotificationsIntegration(t *testing.T) {
+	guestUser := SetupGuestUser(t)
+	hostUser := SetupHostUser(t)
+
+	// Create 2 notifications for guest
+	for i := 0; i < 2; i++ {
+		dto := internal.NewNotificationDTO{
+			ReceiverID: uint(guestUser.ID),
+			Type:       "reservation_requested",
+			Subject:    0,
+			Object:     0,
+		}
+		resp, _ := CreateNotification(hostUser.JWT, dto)
+		defer resp.Body.Close()
+	}
+
+	// Fetch notifications
+	resp, err := GetUserNotifications(guestUser.JWT, 10, 0)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	notifs := ResponseToNotifications(resp)
+	assert.GreaterOrEqual(t, len(notifs), 2)
+	for _, n := range notifs {
+		assert.Equal(t, guestUser.ID, n.ReceiverID)
+	}
+}

--- a/src/test/integration/get_user_notifications_test.go
+++ b/src/test/integration/get_user_notifications_test.go
@@ -15,7 +15,7 @@ func TestGetUserNotificationsIntegration(t *testing.T) {
 
 	// Create 2 notifications for guest
 	for i := 0; i < 2; i++ {
-		dto := internal.NewNotificationDTO{
+		dto := internal.CreateNotificationDTO{
 			ReceiverID: uint(guestUser.ID),
 			Type:       "reservation_requested",
 			Subject:    0,

--- a/src/test/integration/mark_notification_as_read_test.go
+++ b/src/test/integration/mark_notification_as_read_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkNotificationAsReadIntegration(t *testing.T) {
+	guestUser := SetupGuestUser(t)
+	hostUser := SetupHostUser(t)
+
+	// Host creates a notification
+	dto := internal.NewNotificationDTO{
+		ReceiverID: uint(guestUser.ID),
+		Type:       "reservation_requested",
+		Subject:    0,
+		Object:     0,
+	}
+	resp, _ := CreateNotification(hostUser.JWT, dto)
+	defer resp.Body.Close()
+	notif := ResponseToNotification(resp)
+
+	// Mark as read
+	readResp, err := MarkNotificationAsRead(guestUser.JWT, notif.ID)
+	require.NoError(t, err)
+	defer readResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, readResp.StatusCode)
+
+	// Verify notification is marked as read
+	fetchResp, _ := GetUserNotifications(guestUser.JWT, 10, 0)
+	defer fetchResp.Body.Close()
+	notifs := ResponseToNotifications(fetchResp)
+	var found bool
+	for _, n := range notifs {
+		if n.ID == notif.ID {
+			found = n.IsRead
+			break
+		}
+	}
+	assert.True(t, found)
+}

--- a/src/test/integration/mark_notification_as_read_test.go
+++ b/src/test/integration/mark_notification_as_read_test.go
@@ -14,7 +14,7 @@ func TestMarkNotificationAsReadIntegration(t *testing.T) {
 	hostUser := SetupHostUser(t)
 
 	// Host creates a notification
-	dto := internal.NewNotificationDTO{
+	dto := internal.CreateNotificationDTO{
 		ReceiverID: uint(guestUser.ID),
 		Type:       "reservation_requested",
 		Subject:    0,

--- a/src/test/integration/util.go
+++ b/src/test/integration/util.go
@@ -85,7 +85,7 @@ func LoginUserJWT(usernameOrEmail, password string) string {
 
 // ------------------------ Notifications ------------------------
 
-func CreateNotification(jwt string, dto internal.NewNotificationDTO) (*http.Response, error) {
+func CreateNotification(jwt string, dto internal.CreateNotificationDTO) (*http.Response, error) {
 	jsonBytes, _ := json.Marshal(dto)
 	req, _ := http.NewRequest(http.MethodPost, URL_notification+"notification", bytes.NewBuffer(jsonBytes))
 	req.Header.Add("Authorization", "Bearer "+jwt)

--- a/src/test/integration/util.go
+++ b/src/test/integration/util.go
@@ -1,1 +1,200 @@
 package test
+
+import (
+	"bookem-notification-service/client/userclient"
+	"bookem-notification-service/internal"
+	"bookem-notification-service/util"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const URL_user = "http://user-service:8080/api/"
+const URL_notification = "http://notification-service:8080/api/"
+
+// ------------------------ Helpers ------------------------
+
+func GenName(length int) string {
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterRunes[randInt(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func randInt(max int) int {
+	return int(time.Now().UnixNano() % int64(max))
+}
+
+// ------------------------ Users ------------------------
+
+func RegisterUser(usernameOrEmail, password string, role util.UserRole) (*http.Response, error) {
+	username := usernameOrEmail
+	email := username + "@gmail.com"
+
+	if strings.HasSuffix(usernameOrEmail, "@gmail.com") {
+		username = strings.Split(usernameOrEmail, "@")[0]
+		email = usernameOrEmail
+	}
+
+	dto := map[string]interface{}{
+		"username": username,
+		"password": password,
+		"email":    email,
+		"role":     string(role),
+		"name":     GenName(6),
+		"surname":  GenName(6),
+		"address":  GenName(10),
+	}
+
+	jsonBytes, _ := json.Marshal(dto)
+	return http.Post(URL_user+"register", "application/json", bytes.NewBuffer(jsonBytes))
+}
+
+func LoginUser(usernameOrEmail, password string) (*http.Response, error) {
+	dto := map[string]string{
+		"usernameOrEmail": usernameOrEmail,
+		"password":        password,
+	}
+	jsonBytes, _ := json.Marshal(dto)
+	return http.Post(URL_user+"login", "application/json", bytes.NewBuffer(jsonBytes))
+}
+
+func LoginUserJWT(usernameOrEmail, password string) string {
+	resp, err := LoginUser(usernameOrEmail, password)
+	if err != nil {
+		panic(fmt.Sprintf("login failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var token userclient.JWTDTO
+	if err := json.Unmarshal(bodyBytes, &token); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal jwt: %v", err))
+	}
+	return token.Jwt
+}
+
+// ------------------------ Notifications ------------------------
+
+func CreateNotification(jwt string, dto internal.NewNotificationDTO) (*http.Response, error) {
+	jsonBytes, _ := json.Marshal(dto)
+	req, _ := http.NewRequest(http.MethodPost, URL_notification+"notification", bytes.NewBuffer(jsonBytes))
+	req.Header.Add("Authorization", "Bearer "+jwt)
+	return http.DefaultClient.Do(req)
+}
+
+func GetUserNotifications(jwt string, limit, offset int) (*http.Response, error) {
+	url := fmt.Sprintf("%snotifications?limit=%d&offset=%d", URL_notification, limit, offset)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Add("Authorization", "Bearer "+jwt)
+	return http.DefaultClient.Do(req)
+}
+
+func MarkNotificationAsRead(jwt, notificationID string) (*http.Response, error) {
+	url := fmt.Sprintf("%snotifications/%s/read", URL_notification, notificationID)
+	req, _ := http.NewRequest(http.MethodPut, url, nil)
+	req.Header.Add("Authorization", "Bearer "+jwt)
+	return http.DefaultClient.Do(req)
+}
+
+func GetUnreadNotificationCount(jwt string) (*http.Response, error) {
+	url := URL_notification + "notifications/unread-count"
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Add("Authorization", "Bearer "+jwt)
+	return http.DefaultClient.Do(req)
+}
+
+// ------------------------ Response Parsers ------------------------
+
+func ResponseToNotification(resp *http.Response) internal.NotificationDTO {
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var obj internal.NotificationDTO
+	if err := json.Unmarshal(bodyBytes, &obj); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal notification: %v\nbody: %s", err, string(bodyBytes)))
+	}
+	return obj
+}
+
+func ResponseToNotifications(resp *http.Response) []internal.NotificationDTO {
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var obj []internal.NotificationDTO
+	if err := json.Unmarshal(bodyBytes, &obj); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal notifications: %v\nbody: %s", err, string(bodyBytes)))
+	}
+	return obj
+}
+
+func ResponseToUnreadCount(resp *http.Response) int64 {
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var obj struct {
+		UnreadCount int64 `json:"unreadCount"`
+	}
+	if err := json.Unmarshal(bodyBytes, &obj); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal unread count: %v\nbody: %s", err, string(bodyBytes)))
+	}
+	return obj.UnreadCount
+}
+
+// ------------------------ Convenience Setup ------------------------
+
+type UserInfo struct {
+	ID       uint
+	Username string
+	Password string
+	JWT      string
+}
+
+func SetupGuestUser(t *testing.T) UserInfo {
+	username := "guest_" + GenName(5)
+	password := "pass123"
+
+	resp, err := RegisterUser(username, password, util.Guest)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var userResp struct {
+		ID uint `json:"id"`
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(bodyBytes, &userResp)
+
+	jwt := LoginUserJWT(username, password)
+	return UserInfo{
+		ID:       userResp.ID,
+		Username: username,
+		Password: password,
+		JWT:      jwt,
+	}
+}
+
+func SetupHostUser(t *testing.T) UserInfo {
+	username := "host_" + GenName(5)
+	password := "pass123"
+
+	resp, err := RegisterUser(username, password, util.Host)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var userResp struct {
+		ID uint `json:"id"`
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(bodyBytes, &userResp)
+
+	jwt := LoginUserJWT(username, password)
+	return UserInfo{
+		ID:       userResp.ID,
+		Username: username,
+		Password: password,
+		JWT:      jwt,
+	}
+}

--- a/src/test/unit/create_notification_test.go
+++ b/src/test/unit/create_notification_test.go
@@ -15,7 +15,7 @@ func Test_CreateNotification_Success(t *testing.T) {
 	svc, repo, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{
+	dto := internal.CreateNotificationDTO{
 		ReceiverID:  2,
 		Type:        internal.ReservationRequested,
 		Subject:     100,
@@ -50,7 +50,7 @@ func Test_CreateNotification_UserNotFound(t *testing.T) {
 	svc, _, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+	dto := internal.CreateNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
 
 	userClient.On("FindById", context.Background(), callerID).Return(nil, errors.New("not found"))
 
@@ -64,7 +64,7 @@ func Test_CreateNotification_InvalidRole(t *testing.T) {
 	svc, _, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+	dto := internal.CreateNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
 
 	invalidUser := DefaultUser_Guest
 	invalidUser.Role = "admin"
@@ -80,7 +80,7 @@ func Test_CreateNotification_MissingReceiverID(t *testing.T) {
 	svc, _, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 0, Type: internal.ReservationRequested}
+	dto := internal.CreateNotificationDTO{ReceiverID: 0, Type: internal.ReservationRequested}
 
 	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
 
@@ -95,7 +95,7 @@ func Test_CreateNotification_ReceiverNotFound(t *testing.T) {
 	svc, _, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+	dto := internal.CreateNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
 
 	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
 	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(nil, errors.New("not found"))
@@ -111,7 +111,7 @@ func Test_CreateNotification_MissingType(t *testing.T) {
 	svc, _, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: ""}
+	dto := internal.CreateNotificationDTO{ReceiverID: 2, Type: ""}
 
 	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
 	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(&DefaultUser_Host, nil)
@@ -127,7 +127,7 @@ func Test_CreateNotification_RepoError(t *testing.T) {
 	svc, repo, userClient := CreateTestNotificationService()
 
 	callerID := uint(1)
-	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+	dto := internal.CreateNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
 
 	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
 	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(&DefaultUser_Host, nil)

--- a/src/test/unit/create_notification_test.go
+++ b/src/test/unit/create_notification_test.go
@@ -1,0 +1,142 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_CreateNotification_Success(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{
+		ReceiverID:  2,
+		Type:        internal.ReservationRequested,
+		Subject:     100,
+		Object:      200,
+		StarsNumber: 0,
+	}
+
+	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
+	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(&DefaultUser_Host, nil)
+
+	expected := &internal.Notification{
+		ReceiverID:  dto.ReceiverID,
+		Type:        dto.Type,
+		Subject:     dto.Subject,
+		Object:      dto.Object,
+		StarsNumber: dto.StarsNumber,
+		IsRead:      false,
+		CreatedAt:   time.Now(),
+	}
+	repo.On("Save", context.Background(), mock.AnythingOfType("*internal.Notification")).Return(expected, nil)
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertCalled(t, "Save", context.Background(), mock.AnythingOfType("*internal.Notification"))
+	userClient.AssertCalled(t, "FindById", context.Background(), callerID)
+	userClient.AssertCalled(t, "FindById", context.Background(), dto.ReceiverID)
+}
+
+func Test_CreateNotification_UserNotFound(t *testing.T) {
+	svc, _, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+
+	userClient.On("FindById", context.Background(), callerID).Return(nil, errors.New("not found"))
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.ErrorIs(t, err, internal.ErrUnauthenticated)
+	assert.Nil(t, result)
+}
+
+func Test_CreateNotification_InvalidRole(t *testing.T) {
+	svc, _, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+
+	invalidUser := DefaultUser_Guest
+	invalidUser.Role = "admin"
+	userClient.On("FindById", context.Background(), callerID).Return(&invalidUser, nil)
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.ErrorIs(t, err, internal.ErrUnauthorized)
+	assert.Nil(t, result)
+}
+
+func Test_CreateNotification_MissingReceiverID(t *testing.T) {
+	svc, _, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 0, Type: internal.ReservationRequested}
+
+	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "receiver ID cannot be empty")
+	assert.Nil(t, result)
+}
+
+func Test_CreateNotification_ReceiverNotFound(t *testing.T) {
+	svc, _, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+
+	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
+	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(nil, errors.New("not found"))
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "receiver does not exist")
+	assert.Nil(t, result)
+}
+
+func Test_CreateNotification_MissingType(t *testing.T) {
+	svc, _, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: ""}
+
+	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
+	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(&DefaultUser_Host, nil)
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "notification type cannot be empty")
+	assert.Nil(t, result)
+}
+
+func Test_CreateNotification_RepoError(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	callerID := uint(1)
+	dto := internal.NewNotificationDTO{ReceiverID: 2, Type: internal.ReservationRequested}
+
+	userClient.On("FindById", context.Background(), callerID).Return(&DefaultUser_Guest, nil)
+	userClient.On("FindById", context.Background(), dto.ReceiverID).Return(&DefaultUser_Host, nil)
+
+	repo.On("Save", context.Background(), mock.AnythingOfType("*internal.Notification")).Return(nil, errors.New("db error"))
+
+	result, err := svc.CreateNotification(context.Background(), callerID, dto)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "db error")
+	assert.Nil(t, result)
+}

--- a/src/test/unit/get_unread_notification_count_test.go
+++ b/src/test/unit/get_unread_notification_count_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetUnreadNotificationCount_Success(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+
+	repo.On("CountUnreadNotifications", context.Background(), uint(1)).Return(int64(5), nil)
+
+	count, err := svc.GetUnreadNotificationCount(context.Background(), 1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertCalled(t, "CountUnreadNotifications", context.Background(), uint(1))
+	userClient.AssertCalled(t, "FindById", context.Background(), uint(1))
+}
+
+func Test_GetUnreadNotificationCount_UserNotFound(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(nil, errors.New("not found"))
+
+	count, err := svc.GetUnreadNotificationCount(context.Background(), 1)
+
+	assert.ErrorIs(t, err, internal.ErrUnauthenticated)
+	assert.Equal(t, int64(0), count)
+	repo.AssertNotCalled(t, "CountUnreadNotifications")
+}
+
+func Test_GetUnreadNotificationCount_RepoError(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+
+	repo.On("CountUnreadNotifications", context.Background(), uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.GetUnreadNotificationCount(context.Background(), 1)
+
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertCalled(t, "CountUnreadNotifications", context.Background(), uint(1))
+}

--- a/src/test/unit/get_user_notifications_test.go
+++ b/src/test/unit/get_user_notifications_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetUserNotifications_Success(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(2)).Return(&DefaultUser_Host, nil)
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+
+	expected := []internal.Notification{
+		*DefaultNotification,
+		{
+			ID:         DefaultNotification.ID,
+			ReceiverID: 2,
+			Type:       internal.ReservationAccepted,
+			Subject:    1,
+			Object:     2,
+			IsRead:     false,
+		},
+	}
+	repo.On("FindByReceiverID", context.Background(), uint(2), 10, 0).Return(expected, nil)
+
+	result, err := svc.GetUserNotifications(context.Background(), 2, 10, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertCalled(t, "FindByReceiverID", context.Background(), uint(2), 10, 0)
+	userClient.AssertCalled(t, "FindById", context.Background(), uint(2))
+}
+
+func Test_GetUserNotifications_UserNotFound(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(nil, errors.New("not found"))
+
+	result, err := svc.GetUserNotifications(context.Background(), 1, 10, 0)
+
+	assert.ErrorIs(t, err, internal.ErrUnauthenticated)
+	assert.Nil(t, result)
+	repo.AssertNotCalled(t, "FindByReceiverID")
+}
+
+func Test_GetUserNotifications_RepoError(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+
+	repo.On("FindByReceiverID", context.Background(), uint(1), 10, 0).Return(nil, errors.New("db error"))
+
+	result, err := svc.GetUserNotifications(context.Background(), 1, 10, 0)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertCalled(t, "FindByReceiverID", context.Background(), uint(1), 10, 0)
+}

--- a/src/test/unit/mark_notification_as_read_test.go
+++ b/src/test/unit/mark_notification_as_read_test.go
@@ -1,0 +1,89 @@
+package test
+
+import (
+	"bookem-notification-service/internal"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_MarkNotificationAsRead_Success(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	notificationID := DefaultNotification.ID.Hex()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+	repo.On("FindByID", context.Background(), notificationID).Return(DefaultNotification, nil)
+	repo.On("MarkAsRead", context.Background(), notificationID).Return(nil)
+
+	err := svc.MarkNotificationAsRead(context.Background(), 1, notificationID)
+
+	assert.NoError(t, err)
+	repo.AssertCalled(t, "FindByID", context.Background(), notificationID)
+	repo.AssertCalled(t, "MarkAsRead", context.Background(), notificationID)
+	userClient.AssertCalled(t, "FindById", context.Background(), uint(1))
+}
+
+func Test_MarkNotificationAsRead_UserNotFound(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(nil, errors.New("not found"))
+
+	err := svc.MarkNotificationAsRead(context.Background(), 1, "some-id")
+
+	assert.ErrorIs(t, err, internal.ErrUnauthenticated)
+	repo.AssertNotCalled(t, "FindByID")
+	repo.AssertNotCalled(t, "MarkAsRead")
+}
+
+func Test_MarkNotificationAsRead_NotificationNotFound(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	notificationID := "nonexistent-id"
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+	repo.On("FindByID", context.Background(), notificationID).Return(nil, errors.New("not found"))
+
+	err := svc.MarkNotificationAsRead(context.Background(), 1, notificationID)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "notification does not exist")
+	repo.AssertCalled(t, "FindByID", context.Background(), notificationID)
+	repo.AssertNotCalled(t, "MarkAsRead")
+}
+
+func Test_MarkNotificationAsRead_UnauthorizedUser(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	notificationID := DefaultNotification.ID.Hex()
+
+	userClient.On("FindById", context.Background(), uint(2)).Return(&DefaultUser_Host, nil)
+
+	foreignNotification := *DefaultNotification
+	foreignNotification.ReceiverID = 99
+	repo.On("FindByID", context.Background(), notificationID).Return(&foreignNotification, nil)
+
+	err := svc.MarkNotificationAsRead(context.Background(), 2, notificationID)
+
+	assert.ErrorIs(t, err, internal.ErrUnauthorized)
+	repo.AssertCalled(t, "FindByID", context.Background(), notificationID)
+	repo.AssertNotCalled(t, "MarkAsRead")
+}
+
+func Test_MarkNotificationAsRead_RepoError(t *testing.T) {
+	svc, repo, userClient := CreateTestNotificationService()
+
+	notificationID := DefaultNotification.ID.Hex()
+
+	userClient.On("FindById", context.Background(), uint(1)).Return(&DefaultUser_Guest, nil)
+	repo.On("FindByID", context.Background(), notificationID).Return(DefaultNotification, nil)
+	repo.On("MarkAsRead", context.Background(), notificationID).Return(errors.New("db error"))
+
+	err := svc.MarkNotificationAsRead(context.Background(), 1, notificationID)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "db error")
+	repo.AssertCalled(t, "MarkAsRead", context.Background(), notificationID)
+}

--- a/src/test/unit/util.go
+++ b/src/test/unit/util.go
@@ -29,6 +29,9 @@ type MockNotificationRepo struct {
 
 func (r *MockNotificationRepo) Save(ctx context.Context, notification *internal.Notification) (*internal.Notification, error) {
 	args := r.Called(ctx, notification)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*internal.Notification), args.Error(1)
 }
 
@@ -47,6 +50,9 @@ func (r *MockNotificationRepo) MarkAsRead(ctx context.Context, id string) error 
 
 func (r *MockNotificationRepo) FindByID(ctx context.Context, id string) (*internal.Notification, error) {
 	args := r.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*internal.Notification), args.Error(1)
 }
 

--- a/src/test/unit/util.go
+++ b/src/test/unit/util.go
@@ -1,1 +1,89 @@
 package test
+
+import (
+	"bookem-notification-service/client/userclient"
+	"bookem-notification-service/internal"
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func CreateTestNotificationService() (
+	internal.Service,
+	*MockNotificationRepo,
+	*MockUserClient,
+) {
+	mockRepo := new(MockNotificationRepo)
+	mockUserClient := new(MockUserClient)
+
+	svc := internal.NewService(mockRepo, mockUserClient)
+	return svc, mockRepo, mockUserClient
+}
+
+// ----------------------------------------------- Mock Notification repo
+
+type MockNotificationRepo struct {
+	mock.Mock
+}
+
+func (r *MockNotificationRepo) Save(ctx context.Context, notification *internal.Notification) (*internal.Notification, error) {
+	args := r.Called(ctx, notification)
+	return args.Get(0).(*internal.Notification), args.Error(1)
+}
+
+func (r *MockNotificationRepo) FindByReceiverID(ctx context.Context, receiverID uint, limit int, offset int) ([]internal.Notification, error) {
+	args := r.Called(ctx, receiverID, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]internal.Notification), args.Error(1)
+}
+
+func (r *MockNotificationRepo) MarkAsRead(ctx context.Context, id string) error {
+	args := r.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (r *MockNotificationRepo) FindByID(ctx context.Context, id string) (*internal.Notification, error) {
+	args := r.Called(ctx, id)
+	return args.Get(0).(*internal.Notification), args.Error(1)
+}
+
+func (r *MockNotificationRepo) CountUnreadNotifications(ctx context.Context, receiverID uint) (int64, error) {
+	args := r.Called(ctx, receiverID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+// ----------------------------------------------- Mock user client
+
+type MockUserClient struct {
+	mock.Mock
+}
+
+func (r *MockUserClient) FindById(context context.Context, id uint) (*userclient.UserDTO, error) {
+	args := r.Called(context, id)
+	user, _ := args.Get(0).(*userclient.UserDTO)
+	return user, args.Error(1)
+}
+
+// ----------------------------------------------- Mock data
+
+var DefaultNotification = &internal.Notification{
+	ID:         primitive.NewObjectID(),
+	ReceiverID: 1,
+	Type:       internal.ReservationRequested,
+	Subject:    1,
+	Object:     2,
+	IsRead:     false,
+}
+
+var DefaultUser_Guest = userclient.UserDTO{
+	Id:   1,
+	Role: "guest",
+}
+
+var DefaultUser_Host = userclient.UserDTO{
+	Id:   2,
+	Role: "host",
+}

--- a/src/util/jwt_middleware.go
+++ b/src/util/jwt_middleware.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bookem-notification-service/client/userclient"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,10 +9,18 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+type UserRole string
+
+const (
+	Guest UserRole = "guest"
+	Host  UserRole = "host"
+	Admin UserRole = "admin"
+)
+
 type Jwt struct {
 	ID       uint
 	Username string
-	Role     userclient.UserRole
+	Role     UserRole
 }
 
 func GetJwtString(ctx *gin.Context) (string, error) {
@@ -57,7 +64,7 @@ func GetJwt(ctx *gin.Context) (*Jwt, error) {
 	jwt := Jwt{
 		ID:       uint(jwtData["sub"].(float64)),
 		Username: jwtData["username"].(string),
-		Role:     userclient.UserRole(jwtData["role"].(string)),
+		Role:     UserRole(jwtData["role"].(string)),
 	}
 
 	return &jwt, nil
@@ -72,7 +79,7 @@ func GetJwtFromString(jwtString string) (*Jwt, error) {
 	jwt := Jwt{
 		ID:       uint(jwtData["sub"].(float64)),
 		Username: jwtData["username"].(string),
-		Role:     userclient.UserRole(jwtData["role"].(string)),
+		Role:     UserRole(jwtData["role"].(string)),
 	}
 
 	return &jwt, nil


### PR DESCRIPTION
Closes #2 

Part of:
- https://github.com/book-em/web-app/pull/40
- https://github.com/book-em/notification-service/pull/5
- https://github.com/book-em/infrastructure/pull/30

Notification preferences (i.e, selecting which notifications to receive) will be implemented in the next PR, together with the other repositories that will utilize this service for creating notifications.

In order to preview notifications on front, you will have to manualy send request to CreateNotification api:
__Endpoint:__ _POST http://localhost:8508/api/notification_ 
__Body example:__ ` {
  "ReceiverId": 2,
  "Type": "room_reviewed",
  "subject": 2,
  "starsNumber": 4,
  "object": 3
}
`
